### PR TITLE
Remove Random BG feature

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -2,7 +2,6 @@
 <html lang="{{ site.lang | default: "en-US" }}">
   {% include head.html %}
   <body>
-    {% include random_background.html %}
     {% include navigation.html %}
     <main id="main_content">
       <div>


### PR DESCRIPTION
This is inconsistent with the new style from the Kocurek theme, so it is being removed from the template.

The corresponding _include in the theme has also been removed for its v1.0 release.